### PR TITLE
Dynamic flags

### DIFF
--- a/common.go
+++ b/common.go
@@ -4,7 +4,6 @@ import "github.com/spf13/pflag"
 
 const(
 	dynamicMarker = "__is_dynamic"
-
 )
 
 

--- a/common.go
+++ b/common.go
@@ -1,11 +1,13 @@
+// Copyright 2015 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
 package flagz
 
 import "github.com/spf13/pflag"
 
-const(
+const (
 	dynamicMarker = "__is_dynamic"
 )
-
 
 func setFlagDynamic(flag *pflag.Flag) {
 	if flag.Annotations == nil {

--- a/common.go
+++ b/common.go
@@ -1,4 +1,4 @@
-package go_flagz
+package flagz
 
 import "github.com/spf13/pflag"
 

--- a/common.go
+++ b/common.go
@@ -1,0 +1,22 @@
+package go_flagz
+
+import "github.com/spf13/pflag"
+
+const(
+	dynamicMarker = "__is_dynamic"
+
+)
+
+
+func setFlagDynamic(flag *pflag.Flag) {
+	if flag.Annotations == nil {
+		flag.Annotations = make(map[string][]string)
+	}
+	flag.Annotations[dynamicMarker] = []string{}
+}
+
+// IsFlagDynamic returns whether the given Flag has been created in a Dynamic mode.
+func IsFlagDynamic(flag *pflag.Flag) bool {
+	_, exists := flag.Annotations[dynamicMarker]
+	return exists
+}

--- a/dynduration.go
+++ b/dynduration.go
@@ -1,4 +1,4 @@
-package go_flagz
+package flagz
 
 import (
 	"fmt"

--- a/dynduration.go
+++ b/dynduration.go
@@ -1,10 +1,14 @@
+// Copyright 2015 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
 package flagz
 
 import (
 	"fmt"
-	"github.com/spf13/pflag"
 	"sync/atomic"
 	"time"
+
+	"github.com/spf13/pflag"
 )
 
 func DynDuration(flagSet *pflag.FlagSet, name string, value time.Duration, usage string) *DynDurationValue {

--- a/dynduration.go
+++ b/dynduration.go
@@ -1,0 +1,51 @@
+package go_flagz
+
+import (
+	"fmt"
+	"github.com/spf13/pflag"
+	"sync/atomic"
+	"time"
+)
+
+func DynDuration(flagSet *pflag.FlagSet, name string, value time.Duration, usage string) *DynDurationValue {
+	dynValue := &DynDurationValue{ptr: (*int64)(&value)}
+	flag := flagSet.VarPF(dynValue, name, "", usage)
+	setFlagDynamic(flag)
+	return dynValue
+}
+
+type DynDurationValue struct {
+	ptr       *int64
+	validator func(time.Duration) error
+}
+
+func (d *DynDurationValue) Set(input string) error {
+	v, err := time.ParseDuration(input)
+	if err != nil {
+		return err
+	}
+
+	if d.validator != nil {
+		if err := d.validator(v); err != nil {
+			return err
+		}
+	}
+	atomic.StoreInt64(d.ptr, (int64)(v))
+	return nil
+}
+
+func (d *DynDurationValue) WithValidator(validator func(time.Duration) error) {
+	d.validator = validator
+}
+
+func (d *DynDurationValue) Type() string {
+	return "dyn_duration"
+}
+
+func (d *DynDurationValue) Get() time.Duration {
+	return (time.Duration)(atomic.LoadInt64(d.ptr))
+}
+
+func (d *DynDurationValue) String() string {
+	return fmt.Sprintf("%v", d.Get())
+}

--- a/dynduration_test.go
+++ b/dynduration_test.go
@@ -1,39 +1,43 @@
+// Copyright 2015 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
 package flagz
 
 import (
 	"testing"
+
 	flag "github.com/spf13/pflag"
 
-	"github.com/stretchr/testify/assert"
-	"time"
 	"fmt"
-)
+	"time"
 
+	"github.com/stretchr/testify/assert"
+)
 
 func TestDynDuration_SetAndGet(t *testing.T) {
 	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
-	dynFlag := DynDuration(set, "some_duration_1", 5 * time.Second, "Use it or lose it")
-	assert.Equal(t, 5 * time.Second, dynFlag.Get(), "value must be default after create")
+	dynFlag := DynDuration(set, "some_duration_1", 5*time.Second, "Use it or lose it")
+	assert.Equal(t, 5*time.Second, dynFlag.Get(), "value must be default after create")
 	err := set.Set("some_duration_1", "10h")
 	assert.NoError(t, err, "setting value must succeed")
-	assert.Equal(t, 10 * time.Hour, dynFlag.Get(), "value must be set after update")
+	assert.Equal(t, 10*time.Hour, dynFlag.Get(), "value must be set after update")
 }
 
 func TestDynDuration_IsMarkedDynamic(t *testing.T) {
 	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
-	DynDuration(set, "some_duration_1", 5* time.Minute, "Use it or lose it")
+	DynDuration(set, "some_duration_1", 5*time.Minute, "Use it or lose it")
 	assert.True(t, IsFlagDynamic(set.Lookup("some_duration_1")))
 }
 
 func TestDynDuration_FiresValidators(t *testing.T) {
 	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
-	validator := func (x time.Duration) error {
-		if x > 1 * time.Hour {
+	validator := func(x time.Duration) error {
+		if x > 1*time.Hour {
 			return fmt.Errorf("too long")
 		}
 		return nil
 	}
-	DynDuration(set, "some_duration_1", 5 * time.Second, "Use it or lose it").WithValidator(validator)
+	DynDuration(set, "some_duration_1", 5*time.Second, "Use it or lose it").WithValidator(validator)
 
 	assert.NoError(t, set.Set("some_duration_1", "50m"), "no error from validator when in range")
 	assert.Error(t, set.Set("some_duration_1", "2h"), "error from validator when value out of range")
@@ -41,7 +45,7 @@ func TestDynDuration_FiresValidators(t *testing.T) {
 
 func Benchmark_Duration_Dyn_Get(b *testing.B) {
 	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
-	value := DynDuration(set, "some_duration_1", 5 * time.Second, "Use it or lose it")
+	value := DynDuration(set, "some_duration_1", 5*time.Second, "Use it or lose it")
 	set.Set("some_duration_1", "10s")
 	for i := 0; i < b.N; i++ {
 		value.Get()
@@ -50,7 +54,7 @@ func Benchmark_Duration_Dyn_Get(b *testing.B) {
 
 func Benchmark_Duration_Normal_get(b *testing.B) {
 	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
-	valPtr := set.Duration("some_duration_1", 5 * time.Second, "Use it or lose it")
+	valPtr := set.Duration("some_duration_1", 5*time.Second, "Use it or lose it")
 	set.Set("some_duration_1", "10s")
 	for i := 0; i < b.N; i++ {
 		x := *valPtr

--- a/dynduration_test.go
+++ b/dynduration_test.go
@@ -1,0 +1,59 @@
+package go_flagz
+
+import (
+	"testing"
+	flag "github.com/spf13/pflag"
+
+	"github.com/stretchr/testify/assert"
+	"time"
+	"fmt"
+)
+
+
+func TestDynDuration_SetAndGet(t *testing.T) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	dynFlag := DynDuration(set, "some_duration_1", 5 * time.Second, "Use it or lose it")
+	assert.Equal(t, 5 * time.Second, dynFlag.Get(), "value must be default after create")
+	err := set.Set("some_duration_1", "10h")
+	assert.NoError(t, err, "setting value must succeed")
+	assert.Equal(t, 10 * time.Hour, dynFlag.Get(), "value must be set after update")
+}
+
+func TestDynDuration_IsMarkedDynamic(t *testing.T) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	DynDuration(set, "some_duration_1", 5* time.Minute, "Use it or lose it")
+	assert.True(t, IsFlagDynamic(set.Lookup("some_duration_1")))
+}
+
+func TestDynDuration_FiresValidators(t *testing.T) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	validator := func (x time.Duration) error {
+		if x > 1 * time.Hour {
+			return fmt.Errorf("too long")
+		}
+		return nil
+	}
+	DynDuration(set, "some_duration_1", 5 * time.Second, "Use it or lose it").WithValidator(validator)
+
+	assert.NoError(t, set.Set("some_duration_1", "50m"), "no error from validator when in range")
+	assert.Error(t, set.Set("some_duration_1", "2h"), "error from validator when value out of range")
+}
+
+func Benchmark_Duration_Dyn_Get(b *testing.B) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	value := DynDuration(set, "some_duration_1", 5 * time.Second, "Use it or lose it")
+	set.Set("some_duration_1", "10s")
+	for i := 0; i < b.N; i++ {
+		value.Get()
+	}
+}
+
+func Benchmark_Duration_Normal_get(b *testing.B) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	valPtr := set.Duration("some_duration_1", 5 * time.Second, "Use it or lose it")
+	set.Set("some_duration_1", "10s")
+	for i := 0; i < b.N; i++ {
+		x := *valPtr
+		x = x
+	}
+}

--- a/dynduration_test.go
+++ b/dynduration_test.go
@@ -1,4 +1,4 @@
-package go_flagz
+package flagz
 
 import (
 	"testing"

--- a/dynfloat64.go
+++ b/dynfloat64.go
@@ -1,4 +1,4 @@
-package go_flagz
+package flagz
 
 import (
 	"fmt"

--- a/dynfloat64.go
+++ b/dynfloat64.go
@@ -1,0 +1,64 @@
+package go_flagz
+
+import (
+	"fmt"
+	"strconv"
+	"sync/atomic"
+	"github.com/spf13/pflag"
+	"unsafe"
+)
+
+
+func DynFloat64(flagSet *pflag.FlagSet, name string, value float64, usage string) *DynFloat64Value {
+	dynValue := &DynFloat64Value{ptr: unsafe.Pointer(&value)}
+	flag := flagSet.VarPF(dynValue, name, "", usage)
+	setFlagDynamic(flag)
+	return dynValue
+}
+
+type DynFloat64Value struct {
+	ptr       unsafe.Pointer
+	validator func(float64) error
+}
+
+func (d *DynFloat64Value) Set(s string) error {
+	val, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return err
+	}
+	if d.validator != nil {
+		if err := d.validator(val); err != nil {
+			return err
+		}
+	}
+	atomic.StorePointer(&d.ptr, unsafe.Pointer(&val))
+	return nil
+}
+
+func (d *DynFloat64Value) WithValidator(validator func(float64) error) {
+	d.validator = validator
+}
+
+func (d *DynFloat64Value) Type() string {
+	return "dyn_float64"
+}
+
+func (d *DynFloat64Value) Get() float64 {
+	p := (*float64)(atomic.LoadPointer(&d.ptr))
+	return *p
+}
+
+func (d *DynFloat64Value) String() string {
+	return fmt.Sprintf("%v", d.Get())
+}
+
+
+// ValidateDynFloat64Range returns a validator function that checks if the flag value is in range.
+func ValidateDynFloat64Range(fromInclusive float64, toInclusive float64) func (float64) error {
+	return func(value float64) error {
+		if value > toInclusive || value < fromInclusive {
+			return fmt.Errorf("value %v not in [%v, %v] range", value, fromInclusive, toInclusive)
+		}
+		return nil
+	}
+}

--- a/dynfloat64.go
+++ b/dynfloat64.go
@@ -1,13 +1,16 @@
+// Copyright 2015 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
 package flagz
 
 import (
 	"fmt"
 	"strconv"
 	"sync/atomic"
-	"github.com/spf13/pflag"
 	"unsafe"
-)
 
+	"github.com/spf13/pflag"
+)
 
 func DynFloat64(flagSet *pflag.FlagSet, name string, value float64, usage string) *DynFloat64Value {
 	dynValue := &DynFloat64Value{ptr: unsafe.Pointer(&value)}
@@ -52,9 +55,8 @@ func (d *DynFloat64Value) String() string {
 	return fmt.Sprintf("%v", d.Get())
 }
 
-
 // ValidateDynFloat64Range returns a validator function that checks if the flag value is in range.
-func ValidateDynFloat64Range(fromInclusive float64, toInclusive float64) func (float64) error {
+func ValidateDynFloat64Range(fromInclusive float64, toInclusive float64) func(float64) error {
 	return func(value float64) error {
 		if value > toInclusive || value < fromInclusive {
 			return fmt.Errorf("value %v not in [%v, %v] range", value, fromInclusive, toInclusive)

--- a/dynint64.go
+++ b/dynint64.go
@@ -1,4 +1,4 @@
-package go_flagz
+package flagz
 
 import (
 	"fmt"

--- a/dynint64.go
+++ b/dynint64.go
@@ -1,12 +1,15 @@
+// Copyright 2015 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
 package flagz
 
 import (
 	"fmt"
 	"strconv"
 	"sync/atomic"
+
 	"github.com/spf13/pflag"
 )
-
 
 func DynInt64(flagSet *pflag.FlagSet, name string, value int64, usage string) *DynInt64Value {
 	dynValue := &DynInt64Value{ptr: &value}
@@ -50,11 +53,10 @@ func (d *DynInt64Value) String() string {
 	return fmt.Sprintf("%v", d.Get())
 }
 
-
 // ValidateDynInt64Range returns a validator function that checks if the flag value is in range.
-func ValidateDynInt64Range(fromInclusive int64, toInclusive int64) func (int64) error {
+func ValidateDynInt64Range(fromInclusive int64, toInclusive int64) func(int64) error {
 	return func(value int64) error {
-		if value > toInclusive || value < fromInclusive{
+		if value > toInclusive || value < fromInclusive {
 			return fmt.Errorf("value %v not in [%v, %v] range", value, fromInclusive, toInclusive)
 		}
 		return nil

--- a/dynint64.go
+++ b/dynint64.go
@@ -1,0 +1,62 @@
+package go_flagz
+
+import (
+	"fmt"
+	"strconv"
+	"sync/atomic"
+	"github.com/spf13/pflag"
+)
+
+
+func DynInt64(flagSet *pflag.FlagSet, name string, value int64, usage string) *DynInt64Value {
+	dynValue := &DynInt64Value{ptr: &value}
+	flag := flagSet.VarPF(dynValue, name, "", usage)
+	setFlagDynamic(flag)
+	return dynValue
+}
+
+type DynInt64Value struct {
+	ptr       *int64
+	validator func(int64) error
+}
+
+func (d *DynInt64Value) Set(s string) error {
+	val, err := strconv.ParseInt(s, 0, 64)
+	if err != nil {
+		return err
+	}
+	if d.validator != nil {
+		if err := d.validator(val); err != nil {
+			return err
+		}
+	}
+	atomic.StoreInt64(d.ptr, val)
+	return nil
+}
+
+func (d *DynInt64Value) WithValidator(validator func(int64) error) {
+	d.validator = validator
+}
+
+func (d *DynInt64Value) Type() string {
+	return "dyn_int64"
+}
+
+func (d *DynInt64Value) Get() int64 {
+	return atomic.LoadInt64(d.ptr)
+}
+
+func (d *DynInt64Value) String() string {
+	return fmt.Sprintf("%v", d.Get())
+}
+
+
+// ValidateDynInt64Range returns a validator function that checks if the flag value is in range.
+func ValidateDynInt64Range(fromInclusive int64, toInclusive int64) func (int64) error {
+	return func(value int64) error {
+		if value > toInclusive || value < fromInclusive{
+			return fmt.Errorf("value %v not in [%v, %v] range", value, fromInclusive, toInclusive)
+		}
+		return nil
+	}
+}

--- a/dynint64_test.go
+++ b/dynint64_test.go
@@ -29,3 +29,23 @@ func TestDynInt64_FiresValidators(t *testing.T) {
 	assert.NoError(t, set.Set("some_int_1", "300"), "no error from validator when in range")
 	assert.Error(t, set.Set("some_int_1", "2001"), "error from validator when value out of range")
 }
+
+func Benchmark_Int64_Dyn_Get(b *testing.B) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	value := DynInt64(set, "some_int_1", 13371337, "Use it or lose it")
+	set.Set("some_int_1", "77007700")
+	for i := 0; i < b.N; i++ {
+		x := value.Get()
+		x = x + 1
+	}
+}
+
+func Benchmark_Int64_Dyn_Normal(b *testing.B) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	valPtr := set.Int64("some_int_1", 13371337, "Use it or lose it")
+	set.Set("some_int_1", "77007700")
+	for i := 0; i < b.N; i++ {
+		x := *valPtr
+		x = x + 1
+	}
+}

--- a/dynint64_test.go
+++ b/dynint64_test.go
@@ -40,7 +40,7 @@ func Benchmark_Int64_Dyn_Get(b *testing.B) {
 	}
 }
 
-func Benchmark_Int64_Dyn_Normal(b *testing.B) {
+func Benchmark_Int64_Normal_Get(b *testing.B) {
 	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
 	valPtr := set.Int64("some_int_1", 13371337, "Use it or lose it")
 	set.Set("some_int_1", "77007700")

--- a/dynint64_test.go
+++ b/dynint64_test.go
@@ -1,0 +1,31 @@
+package go_flagz
+
+import (
+	"testing"
+	flag "github.com/spf13/pflag"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDynInt64_SetAndGet(t *testing.T) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	dynFlag := DynInt64(set, "some_int_1", 13371337, "Use it or lose it")
+	assert.Equal(t, int64(13371337), dynFlag.Get(), "value must be default after create")
+	err := set.Set("some_int_1", "77007700")
+	assert.NoError(t, err, "setting value must succeed")
+	assert.Equal(t, int64(77007700), dynFlag.Get(), "value must be set after update")
+}
+
+func TestDynInt64_IsMarkedDynamic(t *testing.T) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	DynInt64(set, "some_int_1", 13371337, "Use it or lose it")
+	assert.True(t, IsFlagDynamic(set.Lookup("some_int_1")))
+}
+
+func TestDynInt64_FiresValidators(t *testing.T) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	DynInt64(set, "some_int_1", 13371337, "Use it or lose it").WithValidator(ValidateDynInt64Range(0, 2000))
+
+	assert.NoError(t, set.Set("some_int_1", "300"), "no error from validator when in range")
+	assert.NoError(t, set.Set("some_int_1", "2001"), "error from validator when value out of range")
+}

--- a/dynint64_test.go
+++ b/dynint64_test.go
@@ -1,7 +1,11 @@
+// Copyright 2015 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
 package flagz
 
 import (
 	"testing"
+
 	flag "github.com/spf13/pflag"
 
 	"github.com/stretchr/testify/assert"

--- a/dynint64_test.go
+++ b/dynint64_test.go
@@ -1,4 +1,4 @@
-package go_flagz
+package flagz
 
 import (
 	"testing"

--- a/dynint64_test.go
+++ b/dynint64_test.go
@@ -27,5 +27,5 @@ func TestDynInt64_FiresValidators(t *testing.T) {
 	DynInt64(set, "some_int_1", 13371337, "Use it or lose it").WithValidator(ValidateDynInt64Range(0, 2000))
 
 	assert.NoError(t, set.Set("some_int_1", "300"), "no error from validator when in range")
-	assert.NoError(t, set.Set("some_int_1", "2001"), "error from validator when value out of range")
+	assert.Error(t, set.Set("some_int_1", "2001"), "error from validator when value out of range")
 }

--- a/dynstring.go
+++ b/dynstring.go
@@ -1,4 +1,4 @@
-package go_flagz
+package flagz
 
 import (
 	"fmt"

--- a/dynstring.go
+++ b/dynstring.go
@@ -1,11 +1,15 @@
+// Copyright 2015 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
 package flagz
 
 import (
 	"fmt"
-	"github.com/spf13/pflag"
 	"regexp"
 	"sync/atomic"
 	"unsafe"
+
+	"github.com/spf13/pflag"
 )
 
 func DynString(flagSet *pflag.FlagSet, name string, value string, usage string) *DynStringValue {

--- a/dynstring.go
+++ b/dynstring.go
@@ -1,0 +1,58 @@
+package go_flagz
+
+import (
+	"fmt"
+	"github.com/spf13/pflag"
+	"regexp"
+	"sync/atomic"
+	"unsafe"
+)
+
+func DynString(flagSet *pflag.FlagSet, name string, value string, usage string) *DynStringValue {
+	dynValue := &DynStringValue{ptr: unsafe.Pointer(&value)}
+	flag := flagSet.VarPF(dynValue, name, "", usage)
+	setFlagDynamic(flag)
+	return dynValue
+}
+
+type DynStringValue struct {
+	ptr       unsafe.Pointer
+	validator func(string) error
+}
+
+func (d *DynStringValue) Set(val string) error {
+	if d.validator != nil {
+		if err := d.validator(val); err != nil {
+			return err
+		}
+	}
+	atomic.StorePointer(&d.ptr, unsafe.Pointer(&val))
+	return nil
+}
+
+func (d *DynStringValue) WithValidator(validator func(string) error) {
+	d.validator = validator
+}
+
+func (d *DynStringValue) Type() string {
+	return "dyn_string"
+}
+
+func (d *DynStringValue) Get() string {
+	p := (*string)(atomic.LoadPointer(&d.ptr))
+	return *p
+}
+
+func (d *DynStringValue) String() string {
+	return fmt.Sprintf("%v", d.Get())
+}
+
+// ValidateDynStringMatchesRegex returns a validator function that checks all flag's values against regex.
+func ValidateDynStringMatchesRegex(matcher *regexp.Regexp) func(string) error {
+	return func(value string) error {
+		if !matcher.MatchString(value) {
+			return fmt.Errorf("value %v must match regex %v", value, matcher)
+		}
+		return nil
+	}
+}

--- a/dynstring_test.go
+++ b/dynstring_test.go
@@ -1,13 +1,17 @@
+// Copyright 2015 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
 package flagz
 
 import (
 	"testing"
+
 	flag "github.com/spf13/pflag"
 
-	"github.com/stretchr/testify/assert"
 	"regexp"
-)
 
+	"github.com/stretchr/testify/assert"
+)
 
 func TestDynString_SetAndGet(t *testing.T) {
 	set := flag.NewFlagSet("foobar", flag.ContinueOnError)

--- a/dynstring_test.go
+++ b/dynstring_test.go
@@ -1,4 +1,4 @@
-package go_flagz
+package flagz
 
 import (
 	"testing"

--- a/dynstring_test.go
+++ b/dynstring_test.go
@@ -1,0 +1,54 @@
+package go_flagz
+
+import (
+	"testing"
+	flag "github.com/spf13/pflag"
+
+	"github.com/stretchr/testify/assert"
+	"regexp"
+)
+
+
+func TestDynString_SetAndGet(t *testing.T) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	dynFlag := DynString(set, "some_string_1", "something", "Use it or lose it")
+	assert.Equal(t, "something", dynFlag.Get(), "value must be default after create")
+	err := set.Set("some_string_1", "else")
+	assert.NoError(t, err, "setting value must succeed")
+	assert.Equal(t, "else", dynFlag.Get(), "value must be set after update")
+}
+
+func TestDynString_IsMarkedDynamic(t *testing.T) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	DynString(set, "some_string_1", "somethign", "Use it or lose it")
+	assert.True(t, IsFlagDynamic(set.Lookup("some_string_1")))
+}
+
+func TestDynString_FiresValidators(t *testing.T) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	regex := regexp.MustCompile("^[a-z]{2,8}$")
+	DynString(set, "some_string_1", "something", "Use it or lose it").WithValidator(ValidateDynStringMatchesRegex(regex))
+
+	assert.NoError(t, set.Set("some_string_1", "else"), "no error from validator when in range")
+	assert.Error(t, set.Set("some_string_1", "else1"), "error from validator when value out of range")
+}
+
+func Benchmark_String_Dyn_Get(b *testing.B) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	value := DynString(set, "some_string_1", "something", "Use it or lose it")
+	set.Set("some_string_1", "else")
+	for i := 0; i < b.N; i++ {
+		x := value.Get()
+		x = x + "foo"
+	}
+}
+
+func Benchmark_String_Normal_get(b *testing.B) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	valPtr := set.String("some_string_1", "something", "Use it or lose it")
+	set.Set("some_string_1", "else")
+	for i := 0; i < b.N; i++ {
+		x := *valPtr
+		x = x + "foo"
+	}
+}

--- a/dynstringslice.go
+++ b/dynstringslice.go
@@ -1,3 +1,6 @@
+// Copyright 2015 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
 package flagz
 
 import (

--- a/dynstringslice.go
+++ b/dynstringslice.go
@@ -1,0 +1,64 @@
+package go_flagz
+
+import (
+	"encoding/csv"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"unsafe"
+
+	"github.com/spf13/pflag"
+)
+
+func DynStringSlice(flagSet *pflag.FlagSet, name string, value []string, usage string) *DynStringSliceValue {
+	dynValue := &DynStringSliceValue{ptr: unsafe.Pointer(&value)}
+	flag := flagSet.VarPF(dynValue, name, "", usage)
+	setFlagDynamic(flag)
+	return dynValue
+}
+
+type DynStringSliceValue struct {
+	ptr       unsafe.Pointer
+	validator func([]string) error
+}
+
+func (d *DynStringSliceValue) Set(val string) error {
+	v, err := csv.NewReader(strings.NewReader(val)).Read()
+	if err != nil {
+		return err
+	}
+	if d.validator != nil {
+		if err := d.validator(v); err != nil {
+			return err
+		}
+	}
+	atomic.StorePointer(&d.ptr, unsafe.Pointer(&v))
+	return nil
+}
+
+func (d *DynStringSliceValue) WithValidator(validator func([]string) error) {
+	d.validator = validator
+}
+
+func (d *DynStringSliceValue) Type() string {
+	return "dyn_stringslice"
+}
+
+func (d *DynStringSliceValue) Get() []string {
+	p := (*[]string)(atomic.LoadPointer(&d.ptr))
+	return *p
+}
+
+func (d *DynStringSliceValue) String() string {
+	return fmt.Sprintf("%v", d.Get())
+}
+
+// ValidateDynStringSliceMinElements validates that the given string slice has at least x elements.
+func ValidateDynStringSliceMinElements(count int) func([]string) error {
+	return func(value []string) error {
+		if len(value) < count {
+			return fmt.Errorf("value slice %v must have at least %v elements", value, count)
+		}
+		return nil
+	}
+}

--- a/dynstringslice.go
+++ b/dynstringslice.go
@@ -1,4 +1,4 @@
-package go_flagz
+package flagz
 
 import (
 	"encoding/csv"

--- a/dynstringslice_test.go
+++ b/dynstringslice_test.go
@@ -1,3 +1,6 @@
+// Copyright 2015 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
 package flagz
 
 import (

--- a/dynstringslice_test.go
+++ b/dynstringslice_test.go
@@ -1,0 +1,32 @@
+package go_flagz
+
+import (
+	"testing"
+
+	flag "github.com/spf13/pflag"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDynStringSlice_SetAndGet(t *testing.T) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	dynFlag := DynStringSlice(set, "some_stringslice_1", []string{"foo", "bar"}, "Use it or lose it")
+	assert.Equal(t, []string{"foo", "bar"}, dynFlag.Get(), "value must be default after create")
+	err := set.Set("some_stringslice_1", "car,bar")
+	assert.NoError(t, err, "setting value must succeed")
+	assert.Equal(t, []string{"car", "bar"}, dynFlag.Get(), "value must be set after update")
+}
+
+func TestDynStringSlice_IsMarkedDynamic(t *testing.T) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	DynStringSlice(set, "some_stringslice_1", []string{"foo", "bar"}, "Use it or lose it")
+	assert.True(t, IsFlagDynamic(set.Lookup("some_stringslice_1")))
+}
+
+func TestDynStringSlice_FiresValidators(t *testing.T) {
+	set := flag.NewFlagSet("foobar", flag.ContinueOnError)
+	DynStringSlice(set, "some_stringslice_1", []string{"foo", "bar"}, "Use it or lose it").WithValidator(ValidateDynStringSliceMinElements(2))
+
+	assert.NoError(t, set.Set("some_stringslice_1", "car,far"), "no error from validator when in range")
+	assert.Error(t, set.Set("some_stringslice_1", "car"), "error from validator when value out of range")
+}

--- a/dynstringslice_test.go
+++ b/dynstringslice_test.go
@@ -1,4 +1,4 @@
-package go_flagz
+package flagz
 
 import (
 	"testing"

--- a/etcd/updater.go
+++ b/etcd/updater.go
@@ -1,18 +1,5 @@
-// Updater of Go "flags"-compatible data base on dynamic etcd watches.
-//
 // Copyright 2015 Michal Witkowski. All Rights Reserved.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// See LICENSE for licensing terms.
 
 // Package etcd provides an updater for go "flags"-compatible FlagSets based on dynamic changes in etcd storage.
 

--- a/etcd/updater_test.go
+++ b/etcd/updater_test.go
@@ -1,3 +1,6 @@
+// Copyright 2015 Michal Witkowski. All Rights Reserved.
+// See LICENSE for licensing terms.
+
 package etcd_test
 
 import (
@@ -5,17 +8,17 @@ import (
 	"testing"
 	"time"
 
-	updater "github.com/mwitkow/go-flagz/etcd"
 	"github.com/mwitkow/go-etcd-harness"
+	updater "github.com/mwitkow/go-flagz/etcd"
 	flag "github.com/spf13/pflag"
 
 	"github.com/Sirupsen/logrus"
 	etcd "github.com/coreos/etcd/client"
+	"github.com/mwitkow/go-flagz"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/net/context"
-	"github.com/mwitkow/go-flagz"
-``	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -189,7 +192,7 @@ func (s *UpdaterTestSuite) Test_DynamicUpdate_DoesntUpdateNonDynamicFlags() {
 	assert.EqualValues(s.T(), "initial_value", *someString, "somestring must not be overwritten dynamically")
 
 	eventually(s.T(), 1*time.Second, assert.ObjectsAreEqualValues, "newvalue",
-		func() interface{} { return s.getFlagzValue("somestring")},
+		func() interface{} { return s.getFlagzValue("somestring") },
 		"the non-dynamic somestring shouldnt affect the values in etcd")
 }
 
@@ -206,7 +209,7 @@ func TestUpdaterSuite(t *testing.T) {
 	suite.Run(t, &UpdaterTestSuite{keys: etcd.NewKeysAPI(harness.Client)})
 }
 
-type assertFunc func( expected, actual interface{}) bool
+type assertFunc func(expected, actual interface{}) bool
 type getter func() interface{}
 
 // eventually tries a given Assert function 5 times over the period of time.
@@ -223,7 +226,7 @@ func eventually(t *testing.T, duration time.Duration,
 }
 
 func newCtx() context.Context {
-	c, _ := context.WithTimeout(context.TODO(), 50 * time.Millisecond)
+	c, _ := context.WithTimeout(context.TODO(), 50*time.Millisecond)
 	return c
 }
 

--- a/examples/updater.go
+++ b/examples/updater.go
@@ -1,12 +1,13 @@
 package main
 
 import (
-	"flag"
-	log "github.com/Sirupsen/logrus"
-	etcd "github.com/coreos/etcd/client"
-	flagz_etcd "github.com/mwitkow-io/go-flagz/etcd"
 	"os"
 	"time"
+
+	log "github.com/Sirupsen/logrus"
+	etcd "github.com/coreos/etcd/client"
+	"github.com/mwitkow/go-flagz/watcher"
+	flag "github.com/spf13/pflag"
 )
 
 var (
@@ -24,15 +25,15 @@ func main() {
 	if err != nil {
 		log.Fatalf("Failed setting up %v", err)
 	}
-	updater, err := flagz_etcd.New(myFlagSet, etcd.KeysAPI(client), "/example/flagz", logger)
+	w, err := watcher.New(myFlagSet, etcd.NewKeysAPI(client), "/example/flagz", logger)
 	if err != nil {
 		log.Fatalf("Failed setting up %v", err)
 	}
-	err = updater.Initialize()
+	err = w.Initialize()
 	if err != nil {
 		log.Fatalf("Failed setting up %v", err)
 	}
-	updater.Start()
+	w.Start()
 
 	for true {
 		logger.Infof("someint: %v somestring: %v", *myInt, *myString)


### PR DESCRIPTION
Add flags with `Set` and `Get` functions that use `atomic` pointers to update values.

These are slightly slower, but guarantee race-free without locking.

```
Benchmark_Duration_Dyn_Get-8   	1000000000	         3.15 ns/op
Benchmark_Duration_Normal_get-8	2000000000	         0.28 ns/op
Benchmark_Float64_Dyn_Get-8    	1000000000	         3.55 ns/op
Benchmark_Float64_Normal_Get-8 	2000000000	         0.45 ns/op
Benchmark_Int64_Dyn_Get-8      	1000000000	         3.39 ns/op
Benchmark_Int64_Normal_Get-8   	2000000000	         0.37 ns/op
Benchmark_String_Dyn_Get-8     	100000000	        41.5 ns/op
Benchmark_String_Normal_get-8  	100000000	        36.2 ns/op
```
This should fix https://github.com/mwitkow/go-flagz/issues/3
