### PR TITLE
Flagset checksum and examples

### DIFF
--- a/checksum.go
+++ b/checksum.go
@@ -1,0 +1,21 @@
+package flagz
+
+import (
+	"hash/fnv"
+
+	"github.com/spf13/pflag"
+)
+
+// ChecksumFlagSet will generate a FNV of the *set* values in a FlagSet.
+func ChecksumFlagSet(flagSet *pflag.FlagSet, flagFilter func(flag *pflag.Flag) bool) []byte {
+	h := fnv.New32a()
+	// we use Visit here, since we don't care about the default, unset flags.
+	flagSet.Visit(func(flag *pflag.Flag) {
+		if flagFilter != nil && !flagFilter(flag) {
+			return
+		}
+		h.Write([]byte(flag.Name))
+		h.Write([]byte(flag.Value.String()))
+	})
+	return h.Sum(nil)
+}

--- a/checksum_test.go
+++ b/checksum_test.go
@@ -1,0 +1,62 @@
+package flagz_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mwitkow/go-flagz"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChecksumFlagSet_Differs(t *testing.T) {
+	set := pflag.NewFlagSet("foobar", pflag.ContinueOnError)
+	flagz.DynDuration(set, "some_duration_1", 5*time.Second, "Use it or lose it")
+	flagz.DynInt64(set, "some_int_1", 13371337, "Use it or lose it")
+	set.String("static_string_1", "foobar", "meh")
+
+	preInitChecksum := flagz.ChecksumFlagSet(set, nil)
+	t.Logf("pre init checksum:  %x", preInitChecksum)
+
+	set.Parse([]string{"--some_duration_1", "3s", "--static_string_1", "goodbar"})
+	postInitChecksum := flagz.ChecksumFlagSet(set, nil)
+	t.Logf("post init checksum: %x", postInitChecksum)
+	assert.NotEqual(t, preInitChecksum, postInitChecksum, "checksum must be different init changed 2 flags")
+
+	require.NoError(t, set.Set("some_int_1", "1337"))
+	postSet1Checksum := flagz.ChecksumFlagSet(set, nil)
+	t.Logf("post set1 checksum: %x", postSet1Checksum)
+	assert.NotEqual(t, postInitChecksum, postSet1Checksum, "checksum must be different after a internal flag change")
+
+	require.NoError(t, set.Set("some_duration_1", "4s"))
+	postSet2Checksum := flagz.ChecksumFlagSet(set, nil)
+	t.Logf("post set2 checksum: %x", postSet2Checksum)
+	assert.NotEqual(t, postSet1Checksum, postSet2Checksum, "checksum must be different after a internal flag change")
+
+	require.NoError(t, set.Set("some_duration_1", "3s"))
+	postSet3Checksum := flagz.ChecksumFlagSet(set, nil)
+	t.Logf("post set3 checksum: %x", postSet3Checksum)
+	assert.EqualValues(t, postSet1Checksum, postSet3Checksum, "flipping back duration flag to state at set1 should make it equal")
+}
+
+func TestChecksumFlagSet_Filters(t *testing.T) {
+	filterOnlyDuration := func(flag *pflag.Flag) bool { return flag.Name == "some_duration_1" }
+	set := pflag.NewFlagSet("foobar", pflag.ContinueOnError)
+	flagz.DynDuration(set, "some_duration_1", 5*time.Second, "Use it or lose it")
+	flagz.DynInt64(set, "some_int_1", 13371337, "Use it or lose it")
+
+	set.Parse([]string{"--some_duration_1", "3s", "--some_int_1", "1337"})
+	postInitChecksum := flagz.ChecksumFlagSet(set, filterOnlyDuration)
+	t.Logf("post init checksum: %x", postInitChecksum)
+
+	require.NoError(t, set.Set("some_int_1", "1337"))
+	postSet1Checksum := flagz.ChecksumFlagSet(set, filterOnlyDuration)
+	t.Logf("post set1 checksum: %x", postSet1Checksum)
+	assert.EqualValues(t, postInitChecksum, postSet1Checksum, "checksum should not include some_int_1 change")
+
+	require.NoError(t, set.Set("some_duration_1", "10s"))
+	postSet2Checksum := flagz.ChecksumFlagSet(set, filterOnlyDuration)
+	t.Logf("post set2 checksum: %x", postSet2Checksum)
+	assert.NotEqual(t, postSet1Checksum, postSet2Checksum, "checksum change when some_duration_1 changes")
+}

--- a/dynjson.go
+++ b/dynjson.go
@@ -4,7 +4,6 @@
 package flagz
 
 import (
-	"fmt"
 	"sync/atomic"
 	"unsafe"
 

--- a/examples/simple_cli/README.md
+++ b/examples/simple_cli/README.md
@@ -1,0 +1,33 @@
+# Simple CLI demo
+
+This demonstrates how dynamic values are being updated.
+
+## Quick set up:
+
+Download [etcd](https://github.com/coreos/etcd/releases), extract and make it available on your `$PATH`.
+
+Launch `etcd` server serving from a `default.data` in `/tmp`:
+
+```sh
+cd /tmp
+etcd 
+```
+
+Set up a set of flags:
+
+```sh
+etcdctl mkdir /example/flagz
+etcdctl set /example/flagz/staticint 9090
+etcdctl set /example/flagz/dynstring foo
+```
+
+Play around:
+
+```sh
+./simple_cli &
+etcdctl set /example/flagz/dynstring bar
+etcdctl set /example/flagz/dynint 7777
+etcdctl set /example/flagz/dynstring bad_value
+```
+
+Profit.

--- a/examples/simple_cli/simple_cli.go
+++ b/examples/simple_cli/simple_cli.go
@@ -12,18 +12,22 @@ import (
 	etcd "github.com/coreos/etcd/client"
 	"github.com/mwitkow/go-flagz/watcher"
 	flag "github.com/spf13/pflag"
+	"github.com/mwitkow/go-flagz"
 )
 
 var (
 	myFlagSet = flag.NewFlagSet("custom_flagset", flag.ContinueOnError)
 
-	myString = myFlagSet.String("somestring", "initial_value", "someusage")
-	myInt    = myFlagSet.Int("someint", 1337, "someusage int")
+
+	staticInt    = myFlagSet.Int32("staticint", 8080, "some static int int")
+
+	dynStr = flagz.DynString(myFlagSet, "dynstring", "initial_value", "someusage")
+	dynInt = flagz.DynInt64(myFlagSet, "dynint", 1337, "someusage int")
 )
 
 func main() {
 	myFlagSet.Parse(os.Args[1:])
-	logger := log.New(os.Stderr, "updater", 0)
+	logger := log.New(os.Stderr, "wr ", log.LstdFlags)
 
 	client, err := etcd.New(etcd.Config{Endpoints: []string{"http://localhost:2379"}})
 	if err != nil {
@@ -40,7 +44,10 @@ func main() {
 	w.Start()
 
 	for true {
-		logger.Printf("someint: %v somestring: %v", *myInt, *myString)
+		logger.Printf("staticint: %v dynint: %v dynstring: %v",
+			*staticInt,
+			dynInt.Get(),
+			dynStr.Get())
 		time.Sleep(1500 * time.Millisecond)
 	}
 }

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -1,7 +1,7 @@
 // Copyright 2015 Michal Witkowski. All Rights Reserved.
 // See LICENSE for licensing terms.
 
-// Package etcd provides an updater for go "flags"-compatible FlagSets based on dynamic changes in etcd storage.
+// Package watcher provides an etcd-backed Watcher for syncing FlagSet state with etcd.
 
 package watcher
 
@@ -44,6 +44,7 @@ type loggerCompatible interface {
 
 // New constructs a new Watcher
 func New(set *pflag.FlagSet, keysApi etcd.KeysAPI, etcdPath string, logger loggerCompatible) (*Watcher, error) {
+	set.
 	if !strings.HasSuffix(etcdPath, "/") {
 		etcdPath = etcdPath + "/"
 	}

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -126,7 +126,8 @@ func (u *Watcher) setFlag(flagName string, value string, onlyDynamic bool) error
 	if onlyDynamic && !flagz.IsFlagDynamic(flag) {
 		return errFlagNotDynamic
 	}
-	return flag.Value.Set(value)
+	// do not call flag.Value.Set, instead go through flagSet.Set to change "changed" state.
+	return u.flagSet.Set(flagName, value)
 }
 
 func (u *Watcher) watchForUpdates() error {

--- a/watcher/watcher.go
+++ b/watcher/watcher.go
@@ -44,7 +44,6 @@ type loggerCompatible interface {
 
 // New constructs a new Watcher
 func New(set *pflag.FlagSet, keysApi etcd.KeysAPI, etcdPath string, logger loggerCompatible) (*Watcher, error) {
-	set.
 	if !strings.HasSuffix(etcdPath, "/") {
 		etcdPath = etcdPath + "/"
 	}


### PR DESCRIPTION
This adds a FlagSet checksum function, that allows one to easily compare states of flagsets across machines using a checksum.