### PR TITLE
Fix spurious leading spaces in output of DynStringSetValue.String().

### DIFF
--- a/dynstringset.go
+++ b/dynstringset.go
@@ -86,7 +86,7 @@ func (d *DynStringSetValue) Type() string {
 // String represents the canonical representation of the type.
 func (d *DynStringSetValue) String() string {
 	v := d.Get()
-	arr := make([]string, len(v))
+	arr := make([]string, 0, len(v))
 	for k := range v {
 		arr = append(arr, k)
 	}


### PR DESCRIPTION
The array is allocated with the same size as the map, instead of having the capacity of the map but size zero. This results in unintended leading empty string elements in the array.